### PR TITLE
Fix: Updated Installation Guide with Correct Clone URL and Missing Step #ieeesoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ BioBloom is a comprehensive agricultural technology platform designed to help fa
 
 1. Clone the repository
 ```bash
-git clone https://github.com/yourusername/biobloom.git
+git clone https://github.com/yourusername/Bloom.git
+cd Bloom
 ```
 
 2. Install NPM packages


### PR DESCRIPTION
Linked Issue:
Closes #9 

Description:
This PR updates the README.md installation instructions by:
- Correcting the git clone URL to match the actual repo name casing (Bloom instead of biobloom)
- Adding the missing cd Bloom command after cloning the repo
These changes ensure that new contributors can follow a seamless setup process without confusion or errors.

How to Test:
- Open the updated README.md file.
- Follow the installation steps exactly as written.
- Confirm that the project is cloned correctly and the working directory is set properly with cd Bloom.

Before/After
Before (Original Instructions):
![installationGuide](https://github.com/user-attachments/assets/27465134-29c8-4389-9e69-554896ad245d)

After (Updated Instructions):
![installationGuideFix](https://github.com/user-attachments/assets/62ff2176-8df1-442b-8562-885860a48b47)
